### PR TITLE
Increase counter size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
-.App-body{
+.App-body {
   margin: 25px;
-} 
+}
 
 .App-header {
   background-color: #282c34;
@@ -10,6 +10,11 @@
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: white;
+}
+
+.Timer-controls pre {
+  font-size: 200px;
+  margin: 20px 0;
 }
 
 label {

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -19,7 +19,7 @@ export default function CountdownTimer(props : CountdownTimerProps) {
     const {end, current} = props;
     const timeRemaining = formatTimeRemaining(end - current);
     return (
-        <pre style={{fontSize: 'xx-large'}}>
+        <pre>
             {timeRemaining}
         </pre>
     )

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -12,7 +12,7 @@ function formatTimeRemaining(totalSecondsRemaining : number) {
     const secondsRemaining = totalSecondsRemaining % 60;
     const paddedMinutesRemaining = minutesRemaining < 10 ? ("0" + minutesRemaining) : ("" + minutesRemaining);
     const paddedSecondsRemaining = secondsRemaining < 10 ? ("0" + secondsRemaining) : ("" + secondsRemaining);
-    return `${pastDue ? "-" : " "}${paddedMinutesRemaining}:${paddedSecondsRemaining}`;
+    return `${pastDue ? "-" : ""}${paddedMinutesRemaining}:${paddedSecondsRemaining}`;
 }
 
 export default function CountdownTimer(props : CountdownTimerProps) {

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+.Timer-controls pre {
+  font-size: 200px;
+  margin: 20px 0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,3 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-.Timer-controls pre {
-  font-size: 200px;
-  margin: 20px 0;
-}


### PR DESCRIPTION
**Issue**: #3 

## Changes
* Set font-size and margin for counter in stylesheet
* Remove inline style for counter
* Remove unused style for `code` tag
* Remove leading space for non negative numbers 

## Rationale
Make the counter easy to see from across the room

## Considerations
Leading space was removed because it was much more noticeable with the larger font-size. This changes means the numbers will now shift right when they go negative, rather than occupying the same space... this might make the change to negative more noticeable, which might be desirable.