### PR TITLE
Add time remaining to doc title

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,10 @@
   color: white;
 }
 
+.Status {
+  margin-bottom:0;
+}
+
 label {
   display: block;
 }

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -5,7 +5,7 @@ type CountdownTimerProps = {
     current : number
 }
 
-function formatTimeRemaining(totalSecondsRemaining : number) {
+export function formatTimeRemaining(totalSecondsRemaining : number) {
     const pastDue = totalSecondsRemaining < 0;
     totalSecondsRemaining = Math.abs(totalSecondsRemaining);
     const minutesRemaining = Math.floor(totalSecondsRemaining / 60);

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Activity, ActivityType } from '../App';
+import { formatTimeRemaining } from './CountdownTimer';
 import './Status.css';
 
 type StatusProps = {
@@ -17,7 +18,7 @@ function updateFavicon(emoji : string) {
         } else {
             console.error("Could not find favicon link tag");
         }
-    } 
+    }
 }
 
 let title = "";
@@ -25,12 +26,12 @@ function updateTitle(newTitle : string) {
     if (newTitle !== title) {
         title = newTitle;
         document.title = newTitle;
-    } 
+    }
 }
 
 export default function Status(props : StatusProps) {
     const {activity, currentTime} = props;
-    
+
     let icon = "";
     if(activity === null) {
         icon = "💤";
@@ -39,7 +40,7 @@ export default function Status(props : StatusProps) {
     } else {
         icon = "⌛";
     }
-    
+
     let status = "";
     if(activity === null) {
         status = "Idling..."
@@ -49,12 +50,14 @@ export default function Status(props : StatusProps) {
         status = `Focusing on ${activity.goal}...`
     }
 
+    let timeRemaining = "";
+    if(activity !== null) {
+        timeRemaining = `${formatTimeRemaining(activity.scheduledEnd - currentTime)} `
+    }
 
     updateFavicon(icon);
-    updateTitle(status);
+    updateTitle(`${timeRemaining}${status}`);
     return(
-        <div className="Status">
-            <h1 style={{marginBottom: 0}}>{`${icon} ${title}`}</h1>
-        </div>
+        <h1 className="Status">{`${icon} ${status}`}</h1>
     );
 }


### PR DESCRIPTION
**Issue:** #4 

## Changes
* Export `formatTimeRemaining` function from CountdownTimer component
* Add time remaining to document title
* Use `status` in `h1` rather than `title`
* Remove stray trailing whitespaces
* Move style to stylesheet
  - use existing className
* Remove unnecessary div
  - move className to h1

## Rationale
Allow time remaining to be visible when tab is not the open tab in a window

## Considerations
In Chrome the time in the title seems to lag a behind what's on the page by ~1 second... 
Firefox and Safari seem more synchronized. 
I assume Chrome is laggy because it's not optimized to update a html title every second... 🤷🏻 

Maybe want a version of the time formatting without leading zeros to fit more information in less space.